### PR TITLE
Bug fixes and additional suffix sort algorithms

### DIFF
--- a/src/bsdiff/BinaryPatchUtility.cs
+++ b/src/bsdiff/BinaryPatchUtility.cs
@@ -7,608 +7,630 @@ using Logos.Utility.IO;
 
 namespace BsDiff
 {
-	/*
-	The original bsdiff.c source code (http://www.daemonology.net/bsdiff/) is
-	distributed under the following license:
-
-	Copyright 2003-2005 Colin Percival
-	All rights reserved
-
-	Redistribution and use in source and binary forms, with or without
-	modification, are permitted providing that the following conditions 
-	are met:
-	1. Redistributions of source code must retain the above copyright
-		notice, this list of conditions and the following disclaimer.
-	2. Redistributions in binary form must reproduce the above copyright
-		notice, this list of conditions and the following disclaimer in the
-		documentation and/or other materials provided with the distribution.
-
-	THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
-	IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-	WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-	ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
-	DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-	DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-	OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-	HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-	STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-	IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-	POSSIBILITY OF SUCH DAMAGE.
-	*/
-	class BinaryPatchUtility
-	{
-		/// <summary>
-		/// Creates a binary patch (in <a href="http://www.daemonology.net/bsdiff/">bsdiff</a> format) that can be used
-		/// (by <see cref="Apply"/>) to transform <paramref name="oldData"/> into <paramref name="newData"/>.
-		/// </summary>
-		/// <param name="oldData">The original binary data.</param>
-		/// <param name="newData">The new binary data.</param>
-		/// <param name="output">A <see cref="Stream"/> to which the patch will be written.</param>
-		public static void Create(byte[] oldData, byte[] newData, Stream output)
-		{
-			// check arguments
-			if (oldData == null)
-				throw new ArgumentNullException("oldData");
-			if (newData == null)
-				throw new ArgumentNullException("newData");
-			if (output == null)
-				throw new ArgumentNullException("output");
-			if (!output.CanSeek)
-				throw new ArgumentException("Output stream must be seekable.", "output");
-			if (!output.CanWrite)
-				throw new ArgumentException("Output stream must be writable.", "output");
-
-			/* Header is
-				0	8	 "BSDIFF40"
-				8	8	length of bzip2ed ctrl block
-				16	8	length of bzip2ed diff block
-				24	8	length of new file */
-			/* File is
-				0	32	Header
-				32	??	Bzip2ed ctrl block
-				??	??	Bzip2ed diff block
-				??	??	Bzip2ed extra block */
-			byte[] header = new byte[c_headerSize];
-			WriteInt64(c_fileSignature, header, 0); // "BSDIFF40"
-			WriteInt64(0, header, 8);
-			WriteInt64(0, header, 16);
-			WriteInt64(newData.Length, header, 24);
-
-			long startPosition = output.Position;
-			output.Write(header, 0, header.Length);
-
-			int[] I = SuffixSort(oldData);
-
-			byte[] db = new byte[newData.Length + 1];
-			byte[] eb = new byte[newData.Length + 1];
-
-			int dblen = 0;
-			int eblen = 0;
-
-			using (WrappingStream wrappingStream = new WrappingStream(output, Ownership.None))
-			using (BZip2OutputStream bz2Stream = new BZip2OutputStream(wrappingStream))
-			{
-				// compute the differences, writing ctrl as we go
-				int scan = 0;
-				int pos = 0;
-				int len = 0;
-				int lastscan = 0;
-				int lastpos = 0;
-				int lastoffset = 0;
-				while (scan < newData.Length)
-				{
-					int oldscore = 0;
-
-					for (int scsc = scan += len; scan < newData.Length; scan++)
-					{
-						len = Search(I, oldData, newData, scan, 0, oldData.Length, out pos);
-
-						for (; scsc < scan + len; scsc++)
-						{
-							if ((scsc + lastoffset < oldData.Length) && (oldData[scsc + lastoffset] == newData[scsc]))
-								oldscore++;
-						}
-
-						if ((len == oldscore && len != 0) || (len > oldscore + 8))
-							break;
-
-						if ((scan + lastoffset < oldData.Length) && (oldData[scan + lastoffset] == newData[scan]))
-							oldscore--;
-					}
-
-					if (len != oldscore || scan == newData.Length)
-					{
-						int s = 0;
-						int sf = 0;
-						int lenf = 0;
-						for (int i = 0; (lastscan + i < scan) && (lastpos + i < oldData.Length); )
-						{
-							if (oldData[lastpos + i] == newData[lastscan + i])
-								s++;
-							i++;
-							if (s * 2 - i > sf * 2 - lenf)
-							{
-								sf = s;
-								lenf = i;
-							}
-						}
-
-						int lenb = 0;
-						if (scan < newData.Length)
-						{
-							s = 0;
-							int sb = 0;
-							for (int i = 1; (scan >= lastscan + i) && (pos >= i); i++)
-							{
-								if (oldData[pos - i] == newData[scan - i])
-									s++;
-								if (s * 2 - i > sb * 2 - lenb)
-								{
-									sb = s;
-									lenb = i;
-								}
-							}
-						}
-
-						if (lastscan + lenf > scan - lenb)
-						{
-							int overlap = (lastscan + lenf) - (scan - lenb);
-							s = 0;
-							int ss = 0;
-							int lens = 0;
-							for (int i = 0; i < overlap; i++)
-							{
-								if (newData[lastscan + lenf - overlap + i] == oldData[lastpos + lenf - overlap + i])
-									s++;
-								if (newData[scan - lenb + i] == oldData[pos - lenb + i])
-									s--;
-								if (s > ss)
-								{
-									ss = s;
-									lens = i + 1;
-								}
-							}
-
-							lenf += lens - overlap;
-							lenb -= lens;
-						}
-
-						for (int i = 0; i < lenf; i++)
-							db[dblen + i] = (byte) (newData[lastscan + i] - oldData[lastpos + i]);
-						for (int i = 0; i < (scan - lenb) - (lastscan + lenf); i++)
-							eb[eblen + i] = newData[lastscan + lenf + i];
-
-						dblen += lenf;
-						eblen += (scan - lenb) - (lastscan + lenf);
-
-						byte[] buf = new byte[8];
-						WriteInt64(lenf, buf, 0);
-						bz2Stream.Write(buf, 0, 8);
-
-						WriteInt64((scan - lenb) - (lastscan + lenf), buf, 0);
-						bz2Stream.Write(buf, 0, 8);
-
-						WriteInt64((pos - lenb) - (lastpos + lenf), buf, 0);
-						bz2Stream.Write(buf, 0, 8);
-
-						lastscan = scan - lenb;
-						lastpos = pos - lenb;
-						lastoffset = pos - scan;
-					}
-				}
-			}
-
-			// compute size of compressed ctrl data
-			long controlEndPosition = output.Position;
-			WriteInt64(controlEndPosition - startPosition - c_headerSize, header, 8);
-
-			// write compressed diff data
-			using (WrappingStream wrappingStream = new WrappingStream(output, Ownership.None))
-			using (BZip2OutputStream bz2Stream = new BZip2OutputStream(wrappingStream))
-			{
-				bz2Stream.Write(db, 0, dblen);
-			}
-
-			// compute size of compressed diff data
-			long diffEndPosition = output.Position;
-			WriteInt64(diffEndPosition - controlEndPosition, header, 16);
-
-			// write compressed extra data
-			using (WrappingStream wrappingStream = new WrappingStream(output, Ownership.None))
-			using (BZip2OutputStream bz2Stream = new BZip2OutputStream(wrappingStream))
-			{
-				bz2Stream.Write(eb, 0, eblen);
-			}
-
-			// seek to the beginning, write the header, then seek back to end
-			long endPosition = output.Position;
-			output.Position = startPosition;
-			output.Write(header, 0, header.Length);
-			output.Position = endPosition;
-		}
-
-		/// <summary>
-		/// Applies a binary patch (in <a href="http://www.daemonology.net/bsdiff/">bsdiff</a> format) to the data in
-		/// <paramref name="input"/> and writes the results of patching to <paramref name="output"/>.
-		/// </summary>
-		/// <param name="input">A <see cref="Stream"/> containing the input data.</param>
-		/// <param name="openPatchStream">A func that can open a <see cref="Stream"/> positioned at the start of the patch data.
-		/// This stream must support reading and seeking, and <paramref name="openPatchStream"/> must allow multiple streams on
-		/// the patch to be opened concurrently.</param>
-		/// <param name="output">A <see cref="Stream"/> to which the patched data is written.</param>
-		public static void Apply(Stream input, Func<Stream> openPatchStream, Stream output)
-		{
-			// check arguments
-			if (input == null)
-				throw new ArgumentNullException("input");
-			if (openPatchStream == null)
-				throw new ArgumentNullException("openPatchStream");
-			if (output == null)
-				throw new ArgumentNullException("output");
-
-			/*
-			File format:
-				0	8	"BSDIFF40"
-				8	8	X
-				16	8	Y
-				24	8	sizeof(newfile)
-				32	X	bzip2(control block)
-				32+X	Y	bzip2(diff block)
-				32+X+Y	???	bzip2(extra block)
-			with control block a set of triples (x,y,z) meaning "add x bytes
-			from oldfile to x bytes from the diff block; copy y bytes from the
-			extra block; seek forwards in oldfile by z bytes".
-			*/
-			// read header
-			long controlLength, diffLength, newSize;
-			using (Stream patchStream = openPatchStream())
-			{
-				// check patch stream capabilities
-				if (!patchStream.CanRead)
-					throw new ArgumentException("Patch stream must be readable.", "openPatchStream");
-				if (!patchStream.CanSeek)
-					throw new ArgumentException("Patch stream must be seekable.", "openPatchStream");
-
-				byte[] header = patchStream.ReadExactly(c_headerSize);
-
-				// check for appropriate magic
-				long signature = ReadInt64(header, 0);
-				if (signature != c_fileSignature)
-					throw new InvalidOperationException("Corrupt patch.");
-
-				// read lengths from header
-				controlLength = ReadInt64(header, 8);
-				diffLength = ReadInt64(header, 16);
-				newSize = ReadInt64(header, 24);
-				if (controlLength < 0 || diffLength < 0 || newSize < 0)
-					throw new InvalidOperationException("Corrupt patch.");
-			}
-
-			// preallocate buffers for reading and writing
-			const int c_bufferSize = 1048576;
-			byte[] newData = new byte[c_bufferSize];
-			byte[] oldData = new byte[c_bufferSize];
-
-			// prepare to read three parts of the patch in parallel
-			using (Stream compressedControlStream = openPatchStream())
-			using (Stream compressedDiffStream = openPatchStream())
-			using (Stream compressedExtraStream = openPatchStream())
-			{
-				// seek to the start of each part
-				compressedControlStream.Seek(c_headerSize, SeekOrigin.Current);
-				compressedDiffStream.Seek(c_headerSize + controlLength, SeekOrigin.Current);
-				compressedExtraStream.Seek(c_headerSize + controlLength + diffLength, SeekOrigin.Current);
-
-				// decompress each part (to read it)
-				using (BZip2InputStream controlStream = new BZip2InputStream(compressedControlStream))
-				using (BZip2InputStream diffStream = new BZip2InputStream(compressedDiffStream))
-				using (BZip2InputStream extraStream = new BZip2InputStream(compressedExtraStream))
-				{
-					long[] control = new long[3];
-					byte[] buffer = new byte[8];
-
-					int oldPosition = 0;
-					int newPosition = 0;
-					while (newPosition < newSize)
-					{
-						// read control data
-						for (int i = 0; i < 3; i++)
-						{
-							controlStream.ReadExactly(buffer, 0, 8);
-							control[i] = ReadInt64(buffer, 0);
-						}
-
-						// sanity-check
-						if (newPosition + control[0] > newSize)
-							throw new InvalidOperationException("Corrupt patch.");
-
-						// seek old file to the position that the new data is diffed against
-						input.Position = oldPosition;
-
-						int bytesToCopy = (int) control[0];
-						while (bytesToCopy > 0)
-						{
-							int actualBytesToCopy = Math.Min(bytesToCopy, c_bufferSize);
-
-							// read diff string
-							diffStream.ReadExactly(newData, 0, actualBytesToCopy);
-
-							// add old data to diff string
-							int availableInputBytes = Math.Min(actualBytesToCopy, (int) (input.Length - input.Position));
-							input.ReadExactly(oldData, 0, availableInputBytes);
-
-							for (int index = 0; index < availableInputBytes; index++)
-								newData[index] += oldData[index];
-
-							output.Write(newData, 0, actualBytesToCopy);
-
-							// adjust counters
-							newPosition += actualBytesToCopy;
-							oldPosition += actualBytesToCopy;
-							bytesToCopy -= actualBytesToCopy;
-						}
-
-						// sanity-check
-						if (newPosition + control[1] > newSize)
-							throw new InvalidOperationException("Corrupt patch.");
-
-						// read extra string
-						bytesToCopy = (int) control[1];
-						while (bytesToCopy > 0)
-						{
-							int actualBytesToCopy = Math.Min(bytesToCopy, c_bufferSize);
-
-							extraStream.ReadExactly(newData, 0, actualBytesToCopy);
-							output.Write(newData, 0, actualBytesToCopy);
-
-							newPosition += actualBytesToCopy;
-							bytesToCopy -= actualBytesToCopy;
-						}
-
-						// adjust position
-						oldPosition = (int) (oldPosition + control[2]);
-					}
-				}
-			}
-		}
-
-		private static int CompareBytes(byte[] left, int leftOffset, byte[] right, int rightOffset)
-		{
-			for (int index = 0; index < left.Length - leftOffset && index < right.Length - rightOffset; index++)
-			{
-				int diff = left[index + leftOffset] - right[index + rightOffset];
-				if (diff != 0)
-					return diff;
-			}
-			return 0;
-		}
-
-		private static int MatchLength(byte[] oldData, int oldOffset, byte[] newData, int newOffset)
-		{
-			int i;
-			for (i = 0; i < oldData.Length - oldOffset && i < newData.Length - newOffset; i++)
-			{
-				if (oldData[i + oldOffset] != newData[i + newOffset])
-					break;
-			}
-			return i;
-		}
-
-		private static int Search(int[] I, byte[] oldData, byte[] newData, int newOffset, int start, int end, out int pos)
-		{
-			if (end - start < 2)
-			{
-				int startLength = MatchLength(oldData, I[start], newData, newOffset);
-				int endLength = MatchLength(oldData, I[end], newData, newOffset);
-
-				if (startLength > endLength)
-				{
-					pos = I[start];
-					return startLength;
-				}
-				else
-				{
-					pos = I[end];
-					return endLength;
-				}
-			}
-			else
-			{
-				int midPoint = start + (end - start) / 2;
-				return CompareBytes(oldData, I[midPoint], newData, newOffset) < 0 ?
-					Search(I, oldData, newData, newOffset, midPoint, end, out pos) :
-					Search(I, oldData, newData, newOffset, start, midPoint, out pos);
-			}
-		}
-
-		private static void Split(int[] I, int[] v, int start, int len, int h)
-		{
-			if (len < 16)
-			{
-				int j;
-				for (int k = start; k < start + len; k += j)
-				{
-					j = 1;
-					int x = v[I[k] + h];
-					for (int i = 1; k + i < start + len; i++)
-					{
-						if (v[I[k + i] + h] < x)
-						{
-							x = v[I[k + i] + h];
-							j = 0;
-						}
-						if (v[I[k + i] + h] == x)
-						{
-							Swap(ref I[k + j], ref I[k + i]);
-							j++;
-						}
-					}
-					for (int i = 0; i < j; i++)
-						v[I[k + i]] = k + j - 1;
-					if (j == 1)
-						I[k] = -1;
-				}
-			}
-			else
-			{
-				int x = v[I[start + len / 2] + h];
-				int jj = 0;
-				int kk = 0;
-				for (int i2 = start; i2 < start + len; i2++)
-				{
-					if (v[I[i2] + h] < x)
-						jj++;
-					if (v[I[i2] + h] == x)
-						kk++;
-				}
-				jj += start;
-				kk += jj;
-
-				int i = start;
-				int j = 0;
-				int k = 0;
-				while (i < jj)
-				{
-					if (v[I[i] + h] < x)
-					{
-						i++;
-					}
-					else if (v[I[i] + h] == x)
-					{
-						Swap(ref I[i], ref I[jj + j]);
-						j++;
-					}
-					else
-					{
-						Swap(ref I[i], ref I[kk + k]);
-						k++;
-					}
-				}
-
-				while (jj + j < kk)
-				{
-					if (v[I[jj + j] + h] == x)
-					{
-						j++;
-					}
-					else
-					{
-						Swap(ref I[jj + j], ref I[kk + k]);
-						k++;
-					}
-				}
-
-				if (jj > start)
-					Split(I, v, start, jj - start, h);
-
-				for (i = 0; i < kk - jj; i++)
-					v[I[jj + i]] = kk - 1;
-				if (jj == kk - 1)
-					I[jj] = -1;
-
-				if (start + len > kk)
-					Split(I, v, kk, start + len - kk, h);
-			}
-		}
-
-		private static int[] SuffixSort(byte[] oldData)
-		{
-			int[] buckets = new int[256];
-
-			foreach (byte oldByte in oldData)
-				buckets[oldByte]++;
-			for (int i = 1; i < 256; i++)
-				buckets[i] += buckets[i - 1];
-			for (int i = 255; i > 0; i--)
-				buckets[i] = buckets[i - 1];
-			buckets[0] = 0;
-
-			int[] I = new int[oldData.Length + 1];
-			for (int i = 0; i < oldData.Length; i++)
-				I[++buckets[oldData[i]]] = i;
-
-			int[] v = new int[oldData.Length + 1];
-			for (int i = 0; i < oldData.Length; i++)
-				v[i] = buckets[oldData[i]];
-
-			for (int i = 1; i < 256; i++)
-			{
-				if (buckets[i] == buckets[i - 1] + 1)
-					I[buckets[i]] = -1;
-			}
-			I[0] = -1;
-
-			for (int h = 1; I[0] != -(oldData.Length + 1); h += h)
-			{
-				int len = 0;
-				int i = 0;
-				while (i < oldData.Length + 1)
-				{
-					if (I[i] < 0)
-					{
-						len -= I[i];
-						i -= I[i];
-					}
-					else
-					{
-						if (len != 0)
-							I[i - len] = -len;
-						len = v[I[i]] + 1 - i;
-						Split(I, v, i, len, h);
-						i += len;
-						len = 0;
-					}
-				}
-
-				if (len != 0)
-					I[i - len] = -len;
-			}
-
-			for (int i = 0; i < oldData.Length + 1; i++)
-				I[v[i]] = i;
-
-			return I;
-		}
-
-		private static void Swap(ref int first, ref int second)
-		{
-			int temp = first;
-			first = second;
-			second = temp;
-		}
-
-		private static long ReadInt64(byte[] buf, int offset)
-		{
-			long value = buf[offset + 7] & 0x7F;
-
-			for (int index = 6; index >= 0; index--)
-			{
-				value *= 256;
-				value += buf[offset + index];
-			}
-
-			if ((buf[offset + 7] & 0x80) != 0)
-				value = -value;
-
-			return value;
-		}
-
-		private static void WriteInt64(long value, byte[] buf, int offset)
-		{
-			long valueToWrite = value < 0 ? -value : value;
-
-			for (int byteIndex = 0; byteIndex < 8; byteIndex++)
-			{
-				buf[offset + byteIndex] = (byte) (valueToWrite % 256);
-				valueToWrite -= buf[offset + byteIndex];
-				valueToWrite /= 256;
-			}
-
-			if (value < 0)
-				buf[offset + 7] |= 0x80;
-		}
-
-		const long c_fileSignature = 0x3034464649445342L;
-		const int c_headerSize = 32;
-	}
+    /*
+    The original bsdiff.c source code (http://www.daemonology.net/bsdiff/) is
+    distributed under the following license:
+
+    Copyright 2003-2005 Colin Percival
+    All rights reserved
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted providing that the following conditions 
+    are met:
+    1. Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+    IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+    OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+    STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+    IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+    */
+    class BinaryPatchUtility
+    {
+        const long c_fileSignature = 0x3034464649445342L;
+        const int c_headerSize = 32;
+        const int c_bufferSize = 1048576;
+
+        public enum SuffixSortAlgorithm
+        {
+            qsufsort,
+            SAIS
+        }
+
+        /// <summary>
+        /// Creates a binary patch (in <a href="http://www.daemonology.net/bsdiff/">bsdiff</a> format) that can be used
+        /// (by <see cref="Apply"/>) to transform <paramref name="oldData"/> into <paramref name="newData"/>.
+        /// </summary>
+        /// <param name="oldData">The original binary data.</param>
+        /// <param name="newData">The new binary data.</param>
+        /// <param name="output">A <see cref="Stream"/> to which the patch will be written.</param>
+        public static void Create(byte[] oldData, byte[] newData, Stream output, SuffixSortAlgorithm algorithm = SuffixSortAlgorithm.qsufsort)
+        {
+            // check arguments
+            if (oldData == null)
+                throw new ArgumentNullException("oldData");
+            if (newData == null)
+                throw new ArgumentNullException("newData");
+            if (output == null)
+                throw new ArgumentNullException("output");
+            if (!output.CanSeek)
+                throw new ArgumentException("Output stream must be seekable.", "output");
+            if (!output.CanWrite)
+                throw new ArgumentException("Output stream must be writable.", "output");
+
+            /* Header is
+                0	8	 "BSDIFF40"
+                8	8	length of bzip2ed ctrl block
+                16	8	length of bzip2ed diff block
+                24	8	length of new file */
+            /* File is
+                0	32	Header
+                32	??	Bzip2ed ctrl block
+                ??	??	Bzip2ed diff block
+                ??	??	Bzip2ed extra block */
+            byte[] header = new byte[c_headerSize];
+            WriteInt64(c_fileSignature, header, 0); // "BSDIFF40"
+            WriteInt64(0, header, 8);
+            WriteInt64(0, header, 16);
+            WriteInt64(newData.Length, header, 24);
+
+            long startPosition = output.Position;
+            output.Write(header, 0, header.Length);
+
+            int[] I;
+            switch (algorithm)
+            {
+                case SuffixSortAlgorithm.qsufsort:
+                    I = SuffixSort(oldData);
+                    break;
+                case SuffixSortAlgorithm.SAIS:
+                    I = new int[oldData.Length];
+                    SAIS.sufsort(oldData, I, oldData.Length);
+                    break;
+                default:
+                    throw new ArgumentException("Unknown suffix sort algorithm", "algorithm");
+            }
+
+            byte[] db = new byte[newData.Length];
+            byte[] eb = new byte[newData.Length];
+
+            int dblen = 0;
+            int eblen = 0;
+
+            using (WrappingStream wrappingStream = new WrappingStream(output, Ownership.None))
+            using (BZip2OutputStream bz2Stream = new BZip2OutputStream(wrappingStream))
+            {
+                // compute the differences, writing ctrl as we go
+                int scan = 0;
+                int pos = 0;
+                int len = 0;
+                int lastscan = 0;
+                int lastpos = 0;
+                int lastoffset = 0;
+                while (scan < newData.Length)
+                {
+                    int oldscore = 0;
+
+                    for (int scsc = scan += len; scan < newData.Length; scan++)
+                    {
+                        len = Search(I, oldData, newData, scan, 0, oldData.Length, out pos);
+
+                        for (; scsc < scan + len; scsc++)
+                        {
+                            if ((scsc + lastoffset < oldData.Length) && (oldData[scsc + lastoffset] == newData[scsc]))
+                                oldscore++;
+                        }
+
+                        if ((len == oldscore && len != 0) || (len > oldscore + 8))
+                            break;
+
+                        if ((scan + lastoffset < oldData.Length) && (oldData[scan + lastoffset] == newData[scan]))
+                            oldscore--;
+                    }
+
+                    if (len != oldscore || scan == newData.Length)
+                    {
+                        int s = 0;
+                        int sf = 0;
+                        int lenf = 0;
+                        for (int i = 0; (lastscan + i < scan) && (lastpos + i < oldData.Length); )
+                        {
+                            if (oldData[lastpos + i] == newData[lastscan + i])
+                                s++;
+                            i++;
+                            if (s * 2 - i > sf * 2 - lenf)
+                            {
+                                sf = s;
+                                lenf = i;
+                            }
+                        }
+
+                        int lenb = 0;
+                        if (scan < newData.Length)
+                        {
+                            s = 0;
+                            int sb = 0;
+                            for (int i = 1; (scan >= lastscan + i) && (pos >= i); i++)
+                            {
+                                if (oldData[pos - i] == newData[scan - i])
+                                    s++;
+                                if (s * 2 - i > sb * 2 - lenb)
+                                {
+                                    sb = s;
+                                    lenb = i;
+                                }
+                            }
+                        }
+
+                        if (lastscan + lenf > scan - lenb)
+                        {
+                            int overlap = (lastscan + lenf) - (scan - lenb);
+                            s = 0;
+                            int ss = 0;
+                            int lens = 0;
+                            for (int i = 0; i < overlap; i++)
+                            {
+                                if (newData[lastscan + lenf - overlap + i] == oldData[lastpos + lenf - overlap + i])
+                                    s++;
+                                if (newData[scan - lenb + i] == oldData[pos - lenb + i])
+                                    s--;
+                                if (s > ss)
+                                {
+                                    ss = s;
+                                    lens = i + 1;
+                                }
+                            }
+
+                            lenf += lens - overlap;
+                            lenb -= lens;
+                        }
+
+                        for (int i = 0; i < lenf; i++)
+                            db[dblen + i] = (byte)(newData[lastscan + i] - oldData[lastpos + i]);
+                        for (int i = 0; i < (scan - lenb) - (lastscan + lenf); i++)
+                            eb[eblen + i] = newData[lastscan + lenf + i];
+
+                        dblen += lenf;
+                        eblen += (scan - lenb) - (lastscan + lenf);
+
+                        byte[] buf = new byte[8];
+                        WriteInt64(lenf, buf, 0);
+                        bz2Stream.Write(buf, 0, 8);
+
+                        WriteInt64((scan - lenb) - (lastscan + lenf), buf, 0);
+                        bz2Stream.Write(buf, 0, 8);
+
+                        WriteInt64((pos - lenb) - (lastpos + lenf), buf, 0);
+                        bz2Stream.Write(buf, 0, 8);
+
+                        lastscan = scan - lenb;
+                        lastpos = pos - lenb;
+                        lastoffset = pos - scan;
+                    }
+                }
+            }
+
+            // compute size of compressed ctrl data
+            long controlEndPosition = output.Position;
+            WriteInt64(controlEndPosition - startPosition - c_headerSize, header, 8);
+
+            // write compressed diff data
+            using (WrappingStream wrappingStream = new WrappingStream(output, Ownership.None))
+            using (BZip2OutputStream bz2Stream = new BZip2OutputStream(wrappingStream))
+            {
+                bz2Stream.Write(db, 0, dblen);
+            }
+
+            // compute size of compressed diff data
+            long diffEndPosition = output.Position;
+            WriteInt64(diffEndPosition - controlEndPosition, header, 16);
+
+            // write compressed extra data
+            using (WrappingStream wrappingStream = new WrappingStream(output, Ownership.None))
+            using (BZip2OutputStream bz2Stream = new BZip2OutputStream(wrappingStream))
+            {
+                bz2Stream.Write(eb, 0, eblen);
+            }
+
+            // seek to the beginning, write the header, then seek back to end
+            long endPosition = output.Position;
+            output.Position = startPosition;
+            output.Write(header, 0, header.Length);
+            output.Position = endPosition;
+        }
+
+        /// <summary>
+        /// Applies a binary patch (in <a href="http://www.daemonology.net/bsdiff/">bsdiff</a> format) to the data in
+        /// <paramref name="input"/> and writes the results of patching to <paramref name="output"/>.
+        /// </summary>
+        /// <param name="input">A <see cref="Stream"/> containing the input data.</param>
+        /// <param name="openPatchStream">A func that can open a <see cref="Stream"/> positioned at the start of the patch data.
+        /// This stream must support reading and seeking, and <paramref name="openPatchStream"/> must allow multiple streams on
+        /// the patch to be opened concurrently.</param>
+        /// <param name="output">A <see cref="Stream"/> to which the patched data is written.</param>
+        public static void Apply(Stream input, Func<Stream> openPatchStream, Stream output)
+        {
+            // check arguments
+            if (input == null)
+                throw new ArgumentNullException("input");
+            if (openPatchStream == null)
+                throw new ArgumentNullException("openPatchStream");
+            if (output == null)
+                throw new ArgumentNullException("output");
+
+            /*
+            File format:
+                0	8	"BSDIFF40"
+                8	8	X
+                16	8	Y
+                24	8	sizeof(newfile)
+                32	X	bzip2(control block)
+                32+X	Y	bzip2(diff block)
+                32+X+Y	???	bzip2(extra block)
+            with control block a set of triples (x,y,z) meaning "add x bytes
+            from oldfile to x bytes from the diff block; copy y bytes from the
+            extra block; seek forwards in oldfile by z bytes".
+            */
+            // read header
+            long controlLength, diffLength, newSize;
+            using (Stream patchStream = openPatchStream())
+            {
+                // check patch stream capabilities
+                if (!patchStream.CanRead)
+                    throw new ArgumentException("Patch stream must be readable.", "openPatchStream");
+                if (!patchStream.CanSeek)
+                    throw new ArgumentException("Patch stream must be seekable.", "openPatchStream");
+
+                byte[] header = patchStream.ReadExactly(c_headerSize);
+
+                // check for appropriate magic
+                long signature = ReadInt64(header, 0);
+                if (signature != c_fileSignature)
+                    throw new InvalidOperationException("Corrupt patch.");
+
+                // read lengths from header
+                controlLength = ReadInt64(header, 8);
+                diffLength = ReadInt64(header, 16);
+                newSize = ReadInt64(header, 24);
+                if (controlLength < 0 || diffLength < 0 || newSize < 0)
+                    throw new InvalidOperationException("Corrupt patch.");
+            }
+
+            // preallocate buffers for reading and writing
+            byte[] newData = new byte[c_bufferSize];
+            byte[] oldData = new byte[c_bufferSize];
+
+            // prepare to read three parts of the patch in parallel
+            using (Stream compressedControlStream = openPatchStream())
+            using (Stream compressedDiffStream = openPatchStream())
+            using (Stream compressedExtraStream = openPatchStream())
+            {
+                // seek to the start of each part
+                compressedControlStream.Seek(c_headerSize, SeekOrigin.Current);
+                compressedDiffStream.Seek(c_headerSize + controlLength, SeekOrigin.Current);
+                compressedExtraStream.Seek(c_headerSize + controlLength + diffLength, SeekOrigin.Current);
+
+                // decompress each part (to read it)
+                using (BZip2InputStream controlStream = new BZip2InputStream(compressedControlStream))
+                using (BZip2InputStream diffStream = new BZip2InputStream(compressedDiffStream))
+                using (BZip2InputStream extraStream = new BZip2InputStream(compressedExtraStream))
+                {
+                    long[] control = new long[3];
+                    byte[] buffer = new byte[8];
+
+                    int oldPosition = 0;
+                    int newPosition = 0;
+                    while (newPosition < newSize)
+                    {
+                        // read control data
+                        for (int i = 0; i < 3; i++)
+                        {
+                            controlStream.ReadExactly(buffer, 0, 8);
+                            control[i] = ReadInt64(buffer, 0);
+                        }
+
+                        // sanity-check
+                        if (newPosition + control[0] > newSize)
+                            throw new InvalidOperationException("Corrupt patch.");
+
+                        // seek old file to the position that the new data is diffed against
+                        input.Position = oldPosition;
+
+                        int bytesToCopy = (int)control[0];
+                        while (bytesToCopy > 0)
+                        {
+                            int actualBytesToCopy = Math.Min(bytesToCopy, c_bufferSize);
+
+                            // read diff string
+                            diffStream.ReadExactly(newData, 0, actualBytesToCopy);
+
+                            // add old data to diff string
+                            int availableInputBytes = Math.Min(actualBytesToCopy, (int)(input.Length - input.Position));
+                            input.ReadExactly(oldData, 0, availableInputBytes);
+
+                            for (int index = 0; index < availableInputBytes; index++)
+                                newData[index] += oldData[index];
+
+                            output.Write(newData, 0, actualBytesToCopy);
+
+                            // adjust counters
+                            newPosition += actualBytesToCopy;
+                            oldPosition += actualBytesToCopy;
+                            bytesToCopy -= actualBytesToCopy;
+                        }
+
+                        if (newPosition == newSize)
+                            return;
+
+                        // sanity-check
+                        if (newPosition + control[1] > newSize)
+                            throw new InvalidOperationException("Corrupt patch.");
+
+                        // read extra string
+                        bytesToCopy = (int)control[1];
+                        while (bytesToCopy > 0)
+                        {
+                            int actualBytesToCopy = Math.Min(bytesToCopy, c_bufferSize);
+
+                            extraStream.ReadExactly(newData, 0, actualBytesToCopy);
+                            output.Write(newData, 0, actualBytesToCopy);
+
+                            newPosition += actualBytesToCopy;
+                            bytesToCopy -= actualBytesToCopy;
+                        }
+
+                        // adjust position
+                        oldPosition = (int)(oldPosition + control[2]);
+                    }
+                }
+            }
+        }
+
+        private static int CompareBytes(byte[] left, int leftOffset, byte[] right, int rightOffset)
+        {
+            for (int index = 0; index < left.Length - leftOffset && index < right.Length - rightOffset; index++)
+            {
+                int diff = left[index + leftOffset] - right[index + rightOffset];
+                if (diff != 0)
+                    return diff;
+            }
+            return 0;
+        }
+
+        private static int MatchLength(byte[] oldData, int oldOffset, byte[] newData, int newOffset)
+        {
+            int i;
+            for (i = 0; i < oldData.Length - oldOffset && i < newData.Length - newOffset; i++)
+            {
+                if (oldData[i + oldOffset] != newData[i + newOffset])
+                    break;
+            }
+            return i;
+        }
+
+        private static int Search(int[] I, byte[] oldData, byte[] newData, int newOffset, int start, int end, out int pos)
+        {
+            if (end - start < 2)
+            {
+                int startLength = MatchLength(oldData, I[start], newData, newOffset);
+                int endLength = MatchLength(oldData, I[end], newData, newOffset);
+
+                if (startLength > endLength)
+                {
+                    pos = I[start];
+                    return startLength;
+                }
+                else
+                {
+                    pos = I[end];
+                    return endLength;
+                }
+            }
+            else
+            {
+                int midPoint = start + (end - start) / 2;
+                return CompareBytes(oldData, I[midPoint], newData, newOffset) < 0 ?
+                    Search(I, oldData, newData, newOffset, midPoint, end, out pos) :
+                    Search(I, oldData, newData, newOffset, start, midPoint, out pos);
+            }
+        }
+
+        private static void Split(int[] I, int[] v, int start, int len, int h)
+        {
+            if (len < 16)
+            {
+                int j;
+                for (int k = start; k < start + len; k += j)
+                {
+                    j = 1;
+                    int x = v[I[k] + h];
+                    for (int i = 1; k + i < start + len; i++)
+                    {
+                        if (v[I[k + i] + h] < x)
+                        {
+                            x = v[I[k + i] + h];
+                            j = 0;
+                        }
+                        if (v[I[k + i] + h] == x)
+                        {
+                            Swap(ref I[k + j], ref I[k + i]);
+                            j++;
+                        }
+                    }
+                    for (int i = 0; i < j; i++)
+                        v[I[k + i]] = k + j - 1;
+                    if (j == 1)
+                        I[k] = -1;
+                }
+            }
+            else
+            {
+                int x = v[I[start + len / 2] + h];
+                int jj = 0;
+                int kk = 0;
+                for (int i2 = start; i2 < start + len; i2++)
+                {
+                    if (v[I[i2] + h] < x)
+                        jj++;
+                    if (v[I[i2] + h] == x)
+                        kk++;
+                }
+                jj += start;
+                kk += jj;
+
+                int i = start;
+                int j = 0;
+                int k = 0;
+                while (i < jj)
+                {
+                    if (v[I[i] + h] < x)
+                    {
+                        i++;
+                    }
+                    else if (v[I[i] + h] == x)
+                    {
+                        Swap(ref I[i], ref I[jj + j]);
+                        j++;
+                    }
+                    else
+                    {
+                        Swap(ref I[i], ref I[kk + k]);
+                        k++;
+                    }
+                }
+
+                while (jj + j < kk)
+                {
+                    if (v[I[jj + j] + h] == x)
+                    {
+                        j++;
+                    }
+                    else
+                    {
+                        Swap(ref I[jj + j], ref I[kk + k]);
+                        k++;
+                    }
+                }
+
+                if (jj > start)
+                    Split(I, v, start, jj - start, h);
+
+                for (i = 0; i < kk - jj; i++)
+                    v[I[jj + i]] = kk - 1;
+                if (jj == kk - 1)
+                    I[jj] = -1;
+
+                if (start + len > kk)
+                    Split(I, v, kk, start + len - kk, h);
+            }
+        }
+
+        private static int[] SuffixSort(byte[] oldData)
+        {
+            int[] buckets = new int[256];
+
+            foreach (byte oldByte in oldData)
+                buckets[oldByte]++;
+            for (int i = 1; i < 256; i++)
+                buckets[i] += buckets[i - 1];
+            for (int i = 255; i > 0; i--)
+                buckets[i] = buckets[i - 1];
+            buckets[0] = 0;
+
+            int[] I = new int[oldData.Length + 1];
+            for (int i = 0; i < oldData.Length; i++)
+                I[++buckets[oldData[i]]] = i;
+
+            int[] v = new int[oldData.Length + 1];
+            for (int i = 0; i < oldData.Length; i++)
+                v[i] = buckets[oldData[i]];
+
+            for (int i = 1; i < 256; i++)
+            {
+                if (buckets[i] == buckets[i - 1] + 1)
+                    I[buckets[i]] = -1;
+            }
+            I[0] = -1;
+
+            for (int h = 1; I[0] != -(oldData.Length + 1); h += h)
+            {
+                int len = 0;
+                int i = 0;
+                while (i < oldData.Length + 1)
+                {
+                    if (I[i] < 0)
+                    {
+                        len -= I[i];
+                        i -= I[i];
+                    }
+                    else
+                    {
+                        if (len != 0)
+                            I[i - len] = -len;
+                        len = v[I[i]] + 1 - i;
+                        Split(I, v, i, len, h);
+                        i += len;
+                        len = 0;
+                    }
+                }
+
+                if (len != 0)
+                    I[i - len] = -len;
+            }
+
+            for (int i = 0; i < oldData.Length + 1; i++)
+                I[v[i]] = i;
+
+            return I;
+        }
+
+        private static void Swap(ref int first, ref int second)
+        {
+            int temp = first;
+            first = second;
+            second = temp;
+        }
+
+        private static long ReadInt64(byte[] buf, int offset)
+        {
+            long value = buf[offset + 7] & 0x7F;
+
+            for (int index = 6; index >= 0; index--)
+            {
+                value *= 256;
+                value += buf[offset + index];
+            }
+
+            if ((buf[offset + 7] & 0x80) != 0)
+                value = -value;
+
+            return value;
+        }
+
+        private static void WriteInt64(long value, byte[] buf, int offset)
+        {
+            if (value < 0)
+            {
+                value = -value;
+                for (int i = -1; ++i < 8; value >>= 8)
+                    buf[offset + i] = (byte)value;
+                buf[offset + 7] |= 0x80;
+            }
+            else
+            {
+                for (int i = -1; ++i < 8; value >>= 8)
+                    buf[offset + i] = (byte)value;
+            }
+        }
+    }
 }

--- a/src/bsdiff/BsDiff.csproj
+++ b/src/bsdiff/BsDiff.csproj
@@ -86,6 +86,7 @@
     </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SAIS.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/bsdiff/SAIS.cs
+++ b/src/bsdiff/SAIS.cs
@@ -1,0 +1,867 @@
+﻿/*
+ * SAIS.cs for SAIS-CSharp
+ * Copyright (c) 2010 Yuta Mori. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace BsDiff
+{
+    internal interface BaseArray
+    {
+        int this[int i]
+        {
+            set;
+            get;
+        }
+    }
+
+    internal class ByteArray : BaseArray
+    {
+        private byte[] m_array;
+        private int m_pos;
+        public ByteArray(byte[] array, int pos)
+        {
+            m_pos = pos;
+            m_array = array;
+        }
+        ~ByteArray()
+        {
+            m_array = null;
+        }
+        public int this[int i]
+        {
+            set
+            {
+                m_array[i + m_pos] = (byte)value;
+            }
+            get
+            {
+                return (int)m_array[i + m_pos];
+            }
+        }
+    }
+
+    internal class CharArray : BaseArray
+    {
+        private char[] m_array;
+        private int m_pos;
+        public CharArray(char[] array, int pos)
+        {
+            m_pos = pos;
+            m_array = array;
+        }
+        ~CharArray()
+        {
+            m_array = null;
+        }
+        public int this[int i]
+        {
+            set
+            {
+                m_array[i + m_pos] = (char)value;
+            }
+            get
+            {
+                return (int)m_array[i + m_pos];
+            }
+        }
+    }
+
+    internal class IntArray : BaseArray
+    {
+        private int[] m_array;
+        private int m_pos;
+        public IntArray(int[] array, int pos)
+        {
+            m_pos = pos;
+            m_array = array;
+        }
+        ~IntArray()
+        {
+            m_array = null;
+        }
+        public int this[int i]
+        {
+            set
+            {
+                m_array[i + m_pos] = value;
+            }
+            get
+            {
+                return m_array[i + m_pos];
+            }
+        }
+    }
+
+    internal class StringArray : BaseArray
+    {
+        private string m_array;
+        private int m_pos;
+        public StringArray(string array, int pos)
+        {
+            m_pos = pos;
+            m_array = array;
+        }
+        ~StringArray()
+        {
+            m_array = null;
+        }
+        public int this[int i]
+        {
+            set { }
+            get
+            {
+                return (int)m_array[i + m_pos];
+            }
+        }
+    }
+
+    /// <summary>
+    /// An implementation of the induced sorting based suffix array construction algorithm.
+    /// </summary>
+    public static class SAIS
+    {
+        private const int MINBUCKETSIZE = 256;
+
+        private static void getCounts(BaseArray T, BaseArray C, int n, int k)
+        {
+            int i;
+            for (i = 0; i < k; ++i)
+            {
+                C[i] = 0;
+            }
+            for (i = 0; i < n; ++i)
+            {
+                C[T[i]] = C[T[i]] + 1;
+            }
+        }
+
+        private static void getBuckets(BaseArray C, BaseArray B, int k, bool end)
+        {
+            int i, sum = 0;
+            if (end != false)
+            {
+                for (i = 0; i < k; ++i)
+                {
+                    sum += C[i];
+                    B[i] = sum;
+                }
+            }
+            else
+            {
+                for (i = 0; i < k; ++i)
+                {
+                    sum += C[i];
+                    B[i] = sum - C[i];
+                }
+            }
+        }
+
+        /* sort all type LMS suffixes */
+        private static void LMSsort(BaseArray T, int[] SA, BaseArray C, BaseArray B, int n, int k)
+        {
+            int b, i, j;
+            int c0, c1;
+            /* compute SAl */
+            if (C == B)
+            {
+                getCounts(T, C, n, k);
+            }
+            getBuckets(C, B, k, false); /* find starts of buckets */
+            j = n - 1;
+            b = B[c1 = T[j]];
+            --j;
+            SA[b++] = (T[j] < c1) ? ~j : j;
+            for (i = 0; i < n; ++i)
+            {
+                if (0 < (j = SA[i]))
+                {
+                    if ((c0 = T[j]) != c1)
+                    {
+                        B[c1] = b;
+                        b = B[c1 = c0];
+                    } --j;
+                    SA[b++] = (T[j] < c1) ? ~j : j;
+                    SA[i] = 0;
+                }
+                else if (j < 0)
+                {
+                    SA[i] = ~j;
+                }
+            }
+            /* compute SAs */
+            if (C == B)
+            {
+                getCounts(T, C, n, k);
+            }
+            getBuckets(C, B, k, true); /* find ends of buckets */
+            for (i = n - 1, b = B[c1 = 0]; 0 <= i; --i)
+            {
+                if (0 < (j = SA[i]))
+                {
+                    if ((c0 = T[j]) != c1)
+                    {
+                        B[c1] = b;
+                        b = B[c1 = c0];
+                    } --j;
+                    SA[--b] = (T[j] > c1) ? ~(j + 1) : j;
+                    SA[i] = 0;
+                }
+            }
+        }
+
+        private static int LMSpostproc(BaseArray T, int[] SA, int n, int m)
+        {
+            int i, j, p, q, plen, qlen, name;
+            int c0, c1;
+            bool diff;
+
+            /* compact all the sorted substrings into the first m items of SA
+                2*m must be not larger than n (proveable) */
+            for (i = 0;
+            (p = SA[i]) < 0; ++i)
+            {
+                SA[i] = ~p;
+            }
+            if (i < m)
+            {
+                for (j = i, ++i; ; ++i)
+                {
+                    if ((p = SA[i]) < 0)
+                    {
+                        SA[j++] = ~p;
+                        SA[i] = 0;
+                        if (j == m)
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+
+            /* store the length of all substrings */
+            i = n - 1;
+            j = n - 1;
+            c0 = T[n - 1];
+            do
+            {
+                c1 = c0;
+            } while ((0 <= --i) && ((c0 = T[i]) >= c1));
+            for (; 0 <= i; )
+            {
+                do
+                {
+                    c1 = c0;
+                } while ((0 <= --i) && ((c0 = T[i]) <= c1));
+                if (0 <= i)
+                {
+                    SA[m + ((i + 1) >> 1)] = j - i;
+                    j = i + 1;
+                    do
+                    {
+                        c1 = c0;
+                    } while ((0 <= --i) && ((c0 = T[i]) >= c1));
+                }
+            }
+
+            /* find the lexicographic names of all substrings */
+            for (i = 0, name = 0, q = n, qlen = 0; i < m; ++i)
+            {
+                p = SA[i];
+                plen = SA[m + (p >> 1)];
+                diff = true;
+                if ((plen == qlen) && ((q + plen) < n))
+                {
+                    for (j = 0;
+                    (j < plen) && (T[p + j] == T[q + j]); ++j) { }
+                    if (j == plen)
+                    {
+                        diff = false;
+                    }
+                }
+                if (diff != false)
+                {
+                    ++name;
+                    q = p;
+                    qlen = plen;
+                }
+                SA[m + (p >> 1)] = name;
+            }
+
+            return name;
+        }
+
+        /* compute SA and BWT */
+        private static void induceSA(BaseArray T, int[] SA, BaseArray C, BaseArray B, int n, int k)
+        {
+            int b, i, j;
+            int c0, c1;
+            /* compute SAl */
+            if (C == B)
+            {
+                getCounts(T, C, n, k);
+            }
+            getBuckets(C, B, k, false); /* find starts of buckets */
+            j = n - 1;
+            b = B[c1 = T[j]];
+            SA[b++] = ((0 < j) && (T[j - 1] < c1)) ? ~j : j;
+            for (i = 0; i < n; ++i)
+            {
+                j = SA[i];
+                SA[i] = ~j;
+                if (0 < j)
+                {
+                    if ((c0 = T[--j]) != c1)
+                    {
+                        B[c1] = b;
+                        b = B[c1 = c0];
+                    }
+                    SA[b++] = ((0 < j) && (T[j - 1] < c1)) ? ~j : j;
+                }
+            }
+            /* compute SAs */
+            if (C == B)
+            {
+                getCounts(T, C, n, k);
+            }
+            getBuckets(C, B, k, true); /* find ends of buckets */
+            for (i = n - 1, b = B[c1 = 0]; 0 <= i; --i)
+            {
+                if (0 < (j = SA[i]))
+                {
+                    if ((c0 = T[--j]) != c1)
+                    {
+                        B[c1] = b;
+                        b = B[c1 = c0];
+                    }
+                    SA[--b] = ((j == 0) || (T[j - 1] > c1)) ? ~j : j;
+                }
+                else
+                {
+                    SA[i] = ~j;
+                }
+            }
+        }
+        private static int computeBWT(BaseArray T, int[] SA, BaseArray C, BaseArray B, int n, int k)
+        {
+            int b, i, j, pidx = -1;
+            int c0, c1;
+            /* compute SAl */
+            if (C == B)
+            {
+                getCounts(T, C, n, k);
+            }
+            getBuckets(C, B, k, false); /* find starts of buckets */
+            j = n - 1;
+            b = B[c1 = T[j]];
+            SA[b++] = ((0 < j) && (T[j - 1] < c1)) ? ~j : j;
+            for (i = 0; i < n; ++i)
+            {
+                if (0 < (j = SA[i]))
+                {
+                    SA[i] = ~(c0 = T[--j]);
+                    if (c0 != c1)
+                    {
+                        B[c1] = b;
+                        b = B[c1 = c0];
+                    }
+                    SA[b++] = ((0 < j) && (T[j - 1] < c1)) ? ~j : j;
+                }
+                else if (j != 0)
+                {
+                    SA[i] = ~j;
+                }
+            }
+            /* compute SAs */
+            if (C == B)
+            {
+                getCounts(T, C, n, k);
+            }
+            getBuckets(C, B, k, true); /* find ends of buckets */
+            for (i = n - 1, b = B[c1 = 0]; 0 <= i; --i)
+            {
+                if (0 < (j = SA[i]))
+                {
+                    SA[i] = (c0 = T[--j]);
+                    if (c0 != c1)
+                    {
+                        B[c1] = b;
+                        b = B[c1 = c0];
+                    }
+                    SA[--b] = ((0 < j) && (T[j - 1] > c1)) ? ~((int)T[j - 1]) : j;
+                }
+                else if (j != 0)
+                {
+                    SA[i] = ~j;
+                }
+                else
+                {
+                    pidx = i;
+                }
+            }
+            return pidx;
+        }
+
+        /* find the suffix array SA of T[0..n-1] in {0..k-1}^n
+           use a working space (excluding T and SA) of at most 2n+O(1) for a constant alphabet */
+        private static int sais_main(BaseArray T, int[] SA, int fs, int n, int k, bool isbwt)
+        {
+            BaseArray C, B, RA;
+            int i, j, b, m, p, q, name, pidx = 0, newfs;
+            int c0, c1;
+            uint flags = 0;
+
+            if (k <= MINBUCKETSIZE)
+            {
+                C = new IntArray(new int[k], 0);
+                if (k <= fs)
+                {
+                    B = new IntArray(SA, n + fs - k);
+                    flags = 1;
+                }
+                else
+                {
+                    B = new IntArray(new int[k], 0);
+                    flags = 3;
+                }
+            }
+            else if (k <= fs)
+            {
+                C = new IntArray(SA, n + fs - k);
+                if (k <= (fs - k))
+                {
+                    B = new IntArray(SA, n + fs - k * 2);
+                    flags = 0;
+                }
+                else if (k <= (MINBUCKETSIZE * 4))
+                {
+                    B = new IntArray(new int[k], 0);
+                    flags = 2;
+                }
+                else
+                {
+                    B = C;
+                    flags = 8;
+                }
+            }
+            else
+            {
+                C = B = new IntArray(new int[k], 0);
+                flags = 4 | 8;
+            }
+
+            /* stage 1: reduce the problem by at least 1/2
+               sort all the LMS-substrings */
+            getCounts(T, C, n, k);
+            getBuckets(C, B, k, true); /* find ends of buckets */
+            for (i = 0; i < n; ++i)
+            {
+                SA[i] = 0;
+            }
+            b = -1;
+            i = n - 1;
+            j = n;
+            m = 0;
+            c0 = T[n - 1];
+            do
+            {
+                c1 = c0;
+            } while ((0 <= --i) && ((c0 = T[i]) >= c1));
+            for (; 0 <= i; )
+            {
+                do
+                {
+                    c1 = c0;
+                } while ((0 <= --i) && ((c0 = T[i]) <= c1));
+                if (0 <= i)
+                {
+                    if (0 <= b)
+                    {
+                        SA[b] = j;
+                    }
+                    b = --B[c1];
+                    j = i;
+                    ++m;
+                    do
+                    {
+                        c1 = c0;
+                    } while ((0 <= --i) && ((c0 = T[i]) >= c1));
+                }
+            }
+            if (1 < m)
+            {
+                LMSsort(T, SA, C, B, n, k);
+                name = LMSpostproc(T, SA, n, m);
+            }
+            else if (m == 1)
+            {
+                SA[b] = j + 1;
+                name = 1;
+            }
+            else
+            {
+                name = 0;
+            }
+
+            /* stage 2: solve the reduced problem
+               recurse if names are not yet unique */
+            if (name < m)
+            {
+                if ((flags & 4) != 0)
+                {
+                    C = null;
+                    B = null;
+                }
+                if ((flags & 2) != 0)
+                {
+                    B = null;
+                }
+                newfs = (n + fs) - (m * 2);
+                if ((flags & (1 | 4 | 8)) == 0)
+                {
+                    if ((k + name) <= newfs)
+                    {
+                        newfs -= k;
+                    }
+                    else
+                    {
+                        flags |= 8;
+                    }
+                }
+                for (i = m + (n >> 1) - 1, j = m * 2 + newfs - 1; m <= i; --i)
+                {
+                    if (SA[i] != 0)
+                    {
+                        SA[j--] = SA[i] - 1;
+                    }
+                }
+                RA = new IntArray(SA, m + newfs);
+                sais_main(RA, SA, newfs, m, name, false);
+                RA = null;
+
+                i = n - 1;
+                j = m * 2 - 1;
+                c0 = T[n - 1];
+                do
+                {
+                    c1 = c0;
+                } while ((0 <= --i) && ((c0 = T[i]) >= c1));
+                for (; 0 <= i; )
+                {
+                    do
+                    {
+                        c1 = c0;
+                    } while ((0 <= --i) && ((c0 = T[i]) <= c1));
+                    if (0 <= i)
+                    {
+                        SA[j--] = i + 1;
+                        do
+                        {
+                            c1 = c0;
+                        } while ((0 <= --i) && ((c0 = T[i]) >= c1));
+                    }
+                }
+
+                for (i = 0; i < m; ++i)
+                {
+                    SA[i] = SA[m + SA[i]];
+                }
+                if ((flags & 4) != 0)
+                {
+                    C = B = new IntArray(new int[k], 0);
+                }
+                if ((flags & 2) != 0)
+                {
+                    B = new IntArray(new int[k], 0);
+                }
+            }
+
+            /* stage 3: induce the result for the original problem */
+            if ((flags & 8) != 0)
+            {
+                getCounts(T, C, n, k);
+            }
+            /* put all left-most S characters into their buckets */
+            if (1 < m)
+            {
+                getBuckets(C, B, k, true); /* find ends of buckets */
+                i = m - 1;
+                j = n;
+                p = SA[m - 1];
+                c1 = T[p];
+                do
+                {
+                    q = B[c0 = c1];
+                    while (q < j)
+                    {
+                        SA[--j] = 0;
+                    }
+                    do
+                    {
+                        SA[--j] = p;
+                        if (--i < 0)
+                        {
+                            break;
+                        }
+                        p = SA[i];
+                    } while ((c1 = T[p]) == c0);
+                } while (0 <= i);
+                while (0 < j)
+                {
+                    SA[--j] = 0;
+                }
+            }
+            if (isbwt == false)
+            {
+                induceSA(T, SA, C, B, n, k);
+            }
+            else
+            {
+                pidx = computeBWT(T, SA, C, B, n, k);
+            }
+            C = null;
+            B = null;
+            return pidx;
+        }
+
+        /*- Suffixsorting -*/
+        /* byte */
+        /// <summary>
+        /// Constructs the suffix array of a given string in linear time.
+        /// </summary>
+        /// <param name="T">input string</param>
+        /// <param name="SA">output suffix array</param>
+        /// <param name="n">length of the given string</param>
+        /// <returns>0 if no error occurred, -1 or -2 otherwise</returns>
+        public static int sufsort(byte[] T, int[] SA, int n)
+        {
+            if ((T == null) || (SA == null) || (T.Length < n) || (SA.Length < n))
+            {
+                return -1;
+            }
+            if (n <= 1)
+            {
+                if (n == 1)
+                {
+                    SA[0] = 0;
+                }
+                return 0;
+            }
+            return sais_main(new ByteArray(T, 0), SA, 0, n, 256, false);
+        }
+
+        /* char */
+        /// <summary>
+        /// Constructs the suffix array of a given string in linear time.
+        /// </summary>
+        /// <param name="T">input string</param>
+        /// <param name="SA">output suffix array</param>
+        /// <param name="n">length of the given string</param>
+        /// <returns>0 if no error occurred, -1 or -2 otherwise</returns>
+        public static int sufsort(char[] T, int[] SA, int n)
+        {
+            if ((T == null) || (SA == null) || (T.Length < n) || (SA.Length < n))
+            {
+                return -1;
+            }
+            if (n <= 1)
+            {
+                if (n == 1)
+                {
+                    SA[0] = 0;
+                }
+                return 0;
+            }
+            return sais_main(new CharArray(T, 0), SA, 0, n, 65536, false);
+        }
+
+        /* int */
+        /// <summary>
+        /// Constructs the suffix array of a given string in linear time.
+        /// </summary>
+        /// <param name="T">input string</param>
+        /// <param name="SA">output suffix array</param>
+        /// <param name="n">length of the given string</param>
+        /// <param name="k">alphabet size</param>
+        /// <returns>0 if no error occurred, -1 or -2 otherwise</returns>
+        public static int sufsort(int[] T, int[] SA, int n, int k)
+        {
+            if ((T == null) || (SA == null) || (T.Length < n) || (SA.Length < n) || (k <= 0))
+            {
+                return -1;
+            }
+            if (n <= 1)
+            {
+                if (n == 1)
+                {
+                    SA[0] = 0;
+                }
+                return 0;
+            }
+            return sais_main(new IntArray(T, 0), SA, 0, n, k, false);
+        }
+
+        /* string */
+        /// <summary>
+        /// Constructs the suffix array of a given string in linear time.
+        /// </summary>
+        /// <param name="T">input string</param>
+        /// <param name="SA">output suffix array</param>
+        /// <param name="n">length of the given string</param>
+        /// <returns>0 if no error occurred, -1 or -2 otherwise</returns>
+        public static int sufsort(string T, int[] SA, int n)
+        {
+            if ((T == null) || (SA == null) || (T.Length < n) || (SA.Length < n))
+            {
+                return -1;
+            }
+            if (n <= 1)
+            {
+                if (n == 1)
+                {
+                    SA[0] = 0;
+                }
+                return 0;
+            }
+            return sais_main(new StringArray(T, 0), SA, 0, n, 65536, false);
+        }
+
+        /*- Burrows-Wheeler Transform -*/
+        /* byte */
+        /// <summary>
+        /// Constructs the burrows-wheeler transformed string of a given string in linear time.
+        /// </summary>
+        /// <param name="T">input string</param>
+        /// <param name="U">output string</param>
+        /// <param name="A">temporary array</param>
+        /// <param name="n">length of the given string</param>
+        /// <returns>primary index if no error occurred, -1 or -2 otherwise</returns>
+        public static int bwt(byte[] T, byte[] U, int[] A, int n)
+        {
+            int i, pidx;
+            if ((T == null) || (U == null) || (A == null) || (T.Length < n) || (U.Length < n) || (A.Length < n))
+            {
+                return -1;
+            }
+            if (n <= 1)
+            {
+                if (n == 1)
+                {
+                    U[0] = T[0];
+                }
+                return n;
+            }
+            pidx = sais_main(new ByteArray(T, 0), A, 0, n, 256, true);
+            U[0] = T[n - 1];
+            for (i = 0; i < pidx; ++i)
+            {
+                U[i + 1] = (byte)A[i];
+            }
+            for (i += 1; i < n; ++i)
+            {
+                U[i] = (byte)A[i];
+            }
+            return pidx + 1;
+        }
+
+        /* char */
+        /// <summary>
+        /// Constructs the burrows-wheeler transformed string of a given string in linear time.
+        /// </summary>
+        /// <param name="T">input string</param>
+        /// <param name="U">output string</param>
+        /// <param name="A">temporary array</param>
+        /// <param name="n">length of the given string</param>
+        /// <returns>primary index if no error occurred, -1 or -2 otherwise</returns>
+        public static int bwt(char[] T, char[] U, int[] A, int n)
+        {
+            int i, pidx;
+            if ((T == null) || (U == null) || (A == null) || (T.Length < n) || (U.Length < n) || (A.Length < n))
+            {
+                return -1;
+            }
+            if (n <= 1)
+            {
+                if (n == 1)
+                {
+                    U[0] = T[0];
+                }
+                return n;
+            }
+            pidx = sais_main(new CharArray(T, 0), A, 0, n, 65536, true);
+            U[0] = T[n - 1];
+            for (i = 0; i < pidx; ++i)
+            {
+                U[i + 1] = (char)A[i];
+            }
+            for (i += 1; i < n; ++i)
+            {
+                U[i] = (char)A[i];
+            }
+            return pidx + 1;
+        }
+
+        /* int */
+        /// <summary>
+        /// Constructs the burrows-wheeler transformed string of a given string in linear time.
+        /// </summary>
+        /// <param name="T">input string</param>
+        /// <param name="U">output string</param>
+        /// <param name="A">temporary array</param>
+        /// <param name="n">length of the given string</param>
+        /// <param name="k">alphabet size</param>
+        /// <returns>primary index if no error occurred, -1 or -2 otherwise</returns>
+        public static int bwt(int[] T, int[] U, int[] A, int n, int k)
+        {
+            int i, pidx;
+            if ((T == null) || (U == null) || (A == null) || (T.Length < n) || (U.Length < n) || (A.Length < n) || (k <= 0))
+            {
+                return -1;
+            }
+            if (n <= 1)
+            {
+                if (n == 1)
+                {
+                    U[0] = T[0];
+                }
+                return n;
+            }
+            pidx = sais_main(new IntArray(T, 0), A, 0, n, k, true);
+            U[0] = T[n - 1];
+            for (i = 0; i < pidx; ++i)
+            {
+                U[i + 1] = A[i];
+            }
+            for (i += 1; i < n; ++i)
+            {
+                U[i] = A[i];
+            }
+            return pidx + 1;
+        }
+    }
+}

--- a/src/bspatch/BsPatch.csproj
+++ b/src/bspatch/BsPatch.csproj
@@ -82,6 +82,9 @@
     <Compile Include="..\bsdiff\BinaryPatchUtility.cs">
       <Link>BinaryPatchUtility.cs</Link>
     </Compile>
+    <Compile Include="..\bsdiff\SAIS.cs">
+      <Link>SAIS.cs</Link>
+    </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
Added Yuta Mori's induced sort
Added the option to select a SuffixSort algorithm
- bsdiff has a known bug where qsufsort can overflow the stack on files with very large matches, from recursive calls to Split (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=409664)

Replaced WriteInt64 with a faster method
Fixed an erroneous throw if a patch completes without any extra data
Fixed db/eb being allocated with an extra byte
Moved constant fields together
